### PR TITLE
3 crear módulo de usuarios en el panel filament

### DIFF
--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -18,7 +18,7 @@ class UserResource extends Resource
 {
     protected static ?string $model = User::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static ?string $navigationIcon = 'heroicon-o-user-group';
 
     public static function form(Form $form): Form
     {

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\UserResource\Pages;
+use App\Models\User;
+use App\Services\Utils\PasswordGenerator;
+use Filament\Forms;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class UserResource extends Resource
+{
+    protected static ?string $model = User::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Section::make(__('users.User_information'))
+                    ->icon('heroicon-m-user')
+                    ->collapsible()
+                    ->columns(2)
+                    ->schema([
+                        Forms\Components\TextInput::make('name')
+                            ->label(__('users.Name user'))
+                            ->required(),
+                        Forms\Components\TextInput::make('email')
+                            ->translateLabel()
+                            ->email()
+                            ->unique(ignoreRecord: true)
+                            ->required(),
+                    ]),
+
+                Section::make(__('users.Security'))
+                    ->icon('heroicon-m-adjustments-vertical')
+                    ->collapsible()
+                    ->columns(1)
+                    ->schema([
+                        Forms\Components\TextInput::make('password')
+                            ->translateLabel()
+                            ->password()
+                            ->visibleOn('create')
+                            ->revealable()
+                            ->required()
+                            ->prefixAction(
+                                Forms\Components\Actions\Action::make('generate')
+                                    ->icon('heroicon-m-key')
+                                    ->action(function ($set) {
+                                        $set('password', app(PasswordGenerator::class)->generate());
+                                    })
+                            )
+                            ->maxLength(255),
+                    ]),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('email')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('email_verified_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('deleted_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                Tables\Filters\TrashedFilter::make(),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\ForceDeleteBulkAction::make(),
+                    Tables\Actions\RestoreBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListUsers::route('/'),
+            'create' => Pages\CreateUser::route('/create'),
+            'view' => Pages\ViewUser::route('/{record}'),
+            'edit' => Pages\EditUser::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withoutGlobalScopes([
+                SoftDeletingScope::class,
+            ]);
+    }
+}

--- a/app/Filament/Resources/UserResource/Pages/CreateUser.php
+++ b/app/Filament/Resources/UserResource/Pages/CreateUser.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\UserResource\Pages;
+
+use App\Filament\Resources\UserResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateUser extends CreateRecord
+{
+    protected static string $resource = UserResource::class;
+}

--- a/app/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/app/Filament/Resources/UserResource/Pages/EditUser.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Filament\Resources\UserResource\Pages;
+
+use App\Filament\Resources\UserResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditUser extends EditRecord
+{
+    protected static string $resource = UserResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\ViewAction::make(),
+            Actions\DeleteAction::make(),
+            Actions\ForceDeleteAction::make(),
+            Actions\RestoreAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/UserResource/Pages/ListUsers.php
+++ b/app/Filament/Resources/UserResource/Pages/ListUsers.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\UserResource\Pages;
+
+use App\Filament\Resources\UserResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListUsers extends ListRecords
+{
+    protected static string $resource = UserResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/UserResource/Pages/ViewUser.php
+++ b/app/Filament/Resources/UserResource/Pages/ViewUser.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\UserResource\Pages;
+
+use App\Filament\Resources\UserResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewUser extends ViewRecord
+{
+    protected static string $resource = UserResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -11,6 +12,8 @@ class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory, Notifiable;
+
+    use SoftDeletes;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Services/Utils/PasswordGenerator.php
+++ b/app/Services/Utils/PasswordGenerator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Services\Utils;
+
+class PasswordGenerator
+{
+    /**
+     * Generate a random password.
+     */
+    public function generate(int $length = 12): string
+    {
+        $characters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()';
+        $charactersLength = strlen($characters);
+        $randomPassword = '';
+
+        for ($i = 0; $i < $length; $i++) {
+            $randomPassword .= $characters[rand(0, $charactersLength - 1)];
+        }
+
+        return $randomPassword;
+    }
+}

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -19,6 +19,7 @@ return new class extends Migration
             $table->string('password');
             $table->rememberToken();
             $table->timestamps();
+            $table->softDeletes();
         });
 
         Schema::create('password_reset_tokens', function (Blueprint $table) {

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,8 +16,9 @@ class DatabaseSeeder extends Seeder
         // User::factory(10)->create();
 
         User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+            'name' => 'user',
+            'email' => 'admin@gmail.com',
+            'password' => '123',
         ]);
     }
 }


### PR DESCRIPTION
This pull request introduces a new Filament resource for managing users, adds soft delete support to users, and implements a utility for password generation. The changes collectively enable robust user management through an admin interface, including user creation, viewing, editing, deletion (with soft delete), and password generation.

### User Management via Filament Resource

* Added a complete Filament resource (`UserResource`) for users, including form and table definitions, page classes for listing, creating, viewing, and editing users, and support for bulk actions like delete, force delete, and restore. [[1]](diffhunk://#diff-2a48e3a6a61e7a6254887a8a989c5d5a19f9b1b4552dc470cc973ff977e10ad7R1-R130) [[2]](diffhunk://#diff-c216ffe91d25dde0accc20597398c3adc5be4370a744f4a9863766cb37d09866R1-R11) [[3]](diffhunk://#diff-27e01b8472024bbce8dcf9f1f63e613a37bb8722ae3dd836a46d960a327c85a1R1-R22) [[4]](diffhunk://#diff-9ca63fbc532055432384c94c3c4968aab1593de9ad976a2ce8b07bc3d762cddcR1-R19) [[5]](diffhunk://#diff-92dc6242d86c853435c90561f151fbf952f1824bd7a099d2947a992c0c7ba666R1-R19)

### Soft Delete Functionality

* Enabled soft deletes for users by adding `SoftDeletes` to the `User` model and updating the users table migration to include a `deleted_at` column. This allows users to be "deleted" without permanent removal and supports restore/force delete actions in the admin interface. [[1]](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR7) [[2]](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR16-R17) [[3]](diffhunk://#diff-cdba02318dca2b6013d11b385bfe12d51798f22be578484abb12c6d1782373d0R22)

### Password Generation Utility

* Added a new `PasswordGenerator` service class to generate random passwords, which is integrated into the user creation form for easy password generation. [[1]](diffhunk://#diff-a0991bb06d7035daf993655f233020d7b3fc14cd5a15e64de72d398de9b27b0fR1-R22) [[2]](diffhunk://#diff-2a48e3a6a61e7a6254887a8a989c5d5a19f9b1b4552dc470cc973ff977e10ad7R1-R130)

### Seed Data Update

* Updated the database seeder to create a default user with the name `user`, email `admin@gmail.com`, and password `123`.

><img width="1313" height="423" alt="image" src="https://github.com/user-attachments/assets/055a9022-0b2b-42c0-9817-749630ce5cf7" />
