### PR TITLE
feat: add additional fields to Invoice model and migration for enhanc…

### DIFF
--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -16,6 +16,9 @@ class Invoice extends Model
         'correlativo',
         'tipo_doc',
         'fecha_emision',
+        'subtotal',
+        'igv_percentage',
+        'igv',
         'total',
         'estado',
         'client_id',
@@ -23,6 +26,12 @@ class Invoice extends Model
         'xml_path',
         'cdr_path',
         'ticket',
+        'doc_respuesta',
+        'cadena_ticket',
+        'url_ticket',
+        'url_a4',
+        'cadena_xml',
+        'url_xml',
     ];
 
     protected $casts = [

--- a/database/migrations/2025_09_23_114347_create_invoices_table.php
+++ b/database/migrations/2025_09_23_114347_create_invoices_table.php
@@ -17,6 +17,9 @@ return new class extends Migration
             $table->string('correlativo');
             $table->string('tipo_doc');
             $table->datetime('fecha_emision');
+            $table->decimal('subtotal')->nullable();
+            $table->decimal('igv_percentage', 5, 2)->default(18.00);
+            $table->decimal('igv')->nullable();
             $table->decimal('total', 10, 2);
             $table->string('estado')->default('pendiente');
             $table->foreignId('client_id')->nullable()->constrained();
@@ -24,6 +27,12 @@ return new class extends Migration
             $table->string('xml_path')->nullable();
             $table->string('cdr_path')->nullable();
             $table->string('ticket')->nullable();
+            $table->string('doc_respuesta')->nullable();
+            $table->text('cadena_ticket')->nullable();
+            $table->text('url_ticket')->nullable();
+            $table->text('url_a4')->nullable();
+            $table->text('cadena_xml')->nullable();
+            $table->text('url_xml')->nullable();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
This pull request updates the `Invoice` model and its corresponding database migration to support additional invoice-related fields, primarily to enhance the handling of tax calculations and document metadata. The changes ensure the model and the database are in sync with new requirements for storing more detailed invoice information.

**Invoice fields for tax calculation:**

* Added `subtotal`, `igv_percentage`, and `igv` fields to both the `Invoice` model (`app/Models/Invoice.php`) and the invoices table migration (`database/migrations/2025_09_23_114347_create_invoices_table.php`) to support more granular tax calculations. (`[[1]](diffhunk://#diff-2cbcfc25f25e33074bab704ac90e03242b19017dcaa304d64066913f6443bf03R19-R34)`, `[[2]](diffhunk://#diff-0f3ae66272513af307eca3449fcb573e2fabc1724bdf1d23ecb23fa31ab32e1cR20-R35)`)

**Invoice metadata and document management:**

* Added new fields for handling document response and URLs: `doc_respuesta`, `cadena_ticket`, `url_ticket`, `url_a4`, `cadena_xml`, and `url_xml` in both the model and migration, allowing for better tracking of electronic invoice documents and their related resources. (`[[1]](diffhunk://#diff-2cbcfc25f25e33074bab704ac90e03242b19017dcaa304d64066913f6443bf03R19-R34)`, `[[2]](diffhunk://#diff-0f3ae66272513af307eca3449fcb573e2fabc1724bdf1d23ecb23fa31ab32e1cR20-R35)`)…ed invoice data management