### PR TITLE
feat: add PaymentMethod resource with CRUD functionality and Spanish …

### DIFF
--- a/app/Filament/Resources/PaymentMethodResource.php
+++ b/app/Filament/Resources/PaymentMethodResource.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\PaymentMethodResource\Pages;
+use App\Models\PaymentMethod;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class PaymentMethodResource extends Resource
+{
+    protected static ?string $model = PaymentMethod::class;
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('navigation-panel.Administration');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('payment-method.navegation_label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('payment-method.navegation_label');
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('payment-method.navegation_label_singel');
+    }
+
+    protected static ?string $navigationIcon = 'heroicon-o-credit-card';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('name')
+                    ->translateLabel()
+                    ->columnSpanFull()
+                    ->autocomplete(false)
+                    ->required()
+                    ->unique(ignoreRecord: true)
+                    ->maxLength(255),
+                Forms\Components\Textarea::make('description')
+                    ->translateLabel()
+                    ->columnSpanFull()
+                    ->rows(5)
+                    ->autosize()
+                    ->maxLength(255),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPaymentMethods::route('/'),
+            'create' => Pages\CreatePaymentMethod::route('/create'),
+            'edit' => Pages\EditPaymentMethod::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/PaymentMethodResource/Pages/CreatePaymentMethod.php
+++ b/app/Filament/Resources/PaymentMethodResource/Pages/CreatePaymentMethod.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\PaymentMethodResource\Pages;
+
+use App\Filament\Resources\PaymentMethodResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreatePaymentMethod extends CreateRecord
+{
+    protected static string $resource = PaymentMethodResource::class;
+}

--- a/app/Filament/Resources/PaymentMethodResource/Pages/EditPaymentMethod.php
+++ b/app/Filament/Resources/PaymentMethodResource/Pages/EditPaymentMethod.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\PaymentMethodResource\Pages;
+
+use App\Filament\Resources\PaymentMethodResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditPaymentMethod extends EditRecord
+{
+    protected static string $resource = PaymentMethodResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/PaymentMethodResource/Pages/ListPaymentMethods.php
+++ b/app/Filament/Resources/PaymentMethodResource/Pages/ListPaymentMethods.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\PaymentMethodResource\Pages;
+
+use App\Filament\Resources\PaymentMethodResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPaymentMethods extends ListRecords
+{
+    protected static string $resource = PaymentMethodResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/lang/es/payment-method.php
+++ b/lang/es/payment-method.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'navegation_label' => 'Metodos de pago',
+    'navegation_label_singel' => 'Metodo de pago',
+];


### PR DESCRIPTION
This pull request introduces a new Filament resource for managing payment methods, including all necessary CRUD (Create, Read, Update, Delete) pages and supporting localization in Spanish. The changes add the resource definition, associated page classes, and translation strings, enabling administrators to manage payment methods through the Filament admin panel.

**Payment Method Resource Implementation**

* Added the `PaymentMethodResource` class, which defines the Filament resource for payment methods, including form and table schemas, navigation labels, and page routing. (`app/Filament/Resources/PaymentMethodResource.php`)

**CRUD Page Classes**

* Implemented the `ListPaymentMethods`, `CreatePaymentMethod`, and `EditPaymentMethod` page classes to handle listing, creating, and editing payment method records in the admin panel. (`app/Filament/Resources/PaymentMethodResource/Pages/ListPaymentMethods.php`, `app/Filament/Resources/PaymentMethodResource/Pages/CreatePaymentMethod.php`, `app/Filament/Resources/PaymentMethodResource/Pages/EditPaymentMethod.php`) [[1]](diffhunk://#diff-b042cff75f8d07bd436bbc1ccc134f45570de1f8a2452659a65bb7d4c7dcb366R1-R19) [[2]](diffhunk://#diff-148952b6ad1ee6408a7b7c7afe3ec18d092770f2891296236d62a88e819d2adcR1-R11) [[3]](diffhunk://#diff-3c8dfa8391fbd7f408facc139486ec7358830c1c435aaf5cfc8bf7472e3920afR1-R19)

**Localization Support**

* Added Spanish translations for payment method navigation labels to the `lang/es/payment-method.php` file.…localization


><img width="1289" height="454" alt="image" src="https://github.com/user-attachments/assets/94eac5a5-61f2-41d2-b03e-e3402db2a2bc" />
