### PR TITLE
feat: add administrative panel links to navigation and enable profile…

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -7,6 +7,7 @@ use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Navigation\MenuItem;
 use Filament\Pages;
 use Filament\Panel;
 use Filament\PanelProvider;
@@ -40,6 +41,12 @@ class AdminPanelProvider extends PanelProvider
             ->widgets([
                 Widgets\AccountWidget::class,
                 Widgets\FilamentInfoWidget::class,
+            ])
+            ->userMenuItems([
+                'attention' => MenuItem::make()
+                    ->label('Panel Secundario')
+                    ->url('/dashboard')
+                    ->icon('heroicon-s-home'),
             ])
             ->middleware([
                 EncryptCookies::class,

--- a/config/jetstream.php
+++ b/config/jetstream.php
@@ -59,7 +59,7 @@ return [
 
     'features' => [
         // Features::termsAndPrivacyPolicy(),
-        // Features::profilePhotos(),
+        Features::profilePhotos(),
         // Features::api(),
         // Features::teams(['invitations' => true]),
         Features::accountDeletion(),

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -267,7 +267,9 @@
                                         >
                                             Profile
                                         </DropdownLink>
-
+                                        <DropdownLink href="/admin" as="a">
+                                            Panel Administrativo
+                                        </DropdownLink>
                                         <DropdownLink
                                             v-if="
                                                 $page.props.jetstream
@@ -388,7 +390,9 @@
                             >
                                 Profile
                             </ResponsiveNavLink>
-
+                            <ResponsiveNavLink href="/admin" as="a">
+                                Panel Administrativo
+                            </ResponsiveNavLink>
                             <ResponsiveNavLink
                                 v-if="$page.props.jetstream.hasApiFeatures"
                                 :href="route('api-tokens.index')"


### PR DESCRIPTION
This pull request introduces enhancements to the user navigation experience and enables profile photo support. The main changes include adding links to the admin panel in the user dropdown and responsive navigation, enabling profile photo features in Jetstream, and customizing the Filament admin panel's user menu.

**Navigation Improvements:**

* Added a "Panel Administrativo" link to the user dropdown menu in `AppLayout.vue`, allowing users to easily access the admin panel.
* Added a "Panel Administrativo" link to the responsive navigation in `AppLayout.vue` for mobile and smaller screens.

**Admin Panel Customization:**

* Configured the Filament admin panel to include a custom user menu item labeled "Panel Secundario" that links to `/dashboard` with an icon, via the `userMenuItems` method in `AdminPanelProvider.php`.
* Imported the `MenuItem` class to support custom menu items in the Filament admin panel provider.

**Feature Enablement:**

* Enabled Jetstream's profile photo feature by uncommenting the corresponding line in `jetstream.php`.… photos feature

><img width="376" height="248" alt="image" src="https://github.com/user-attachments/assets/68e5d20a-a871-40d8-a48d-53333a654da5" />

