### PR TITLE
fix: disable user registration feature in Fortify configuration

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -144,7 +144,7 @@ return [
     */
 
     'features' => [
-        Features::registration(),
+        // Features::registration(),
         Features::resetPasswords(),
         // Features::emailVerification(),
         Features::updateProfileInformation(),


### PR DESCRIPTION
This pull request makes a small change to the Fortify configuration by disabling user registration. This is done by commenting out the `Features::registration()` line in the `config/fortify.php` file.


><img width="824" height="517" alt="image" src="https://github.com/user-attachments/assets/3cea02ef-60fd-4555-9cc9-656cdbce6773" />
